### PR TITLE
parsing v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
         cibw_arch: ["auto64"]
+        exclude:
+          # mypyc seems to be busted on Windows under Python 3.10
+          - os: windows-latest
+            cibw_python: "cp310-*"
 
     defaults:
       run:

--- a/parsing/_version.py
+++ b/parsing/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = "2.0.0.dev0"
+__version__ = "2.0.0"


### PR DESCRIPTION
This release includes significant refactoring to modernize the codebase
and improve parser generation performance by a factor of 7 to 15
depending on whether the mypycified version is used.

There are breaking changes in the exported classes:

* `Symbol`, `Token`, and `Nonterm` no longer take `parser` as the
  argument.

* The `Spec` class is no longer subclassable.  This is mostly due to its
  mypycification, but also because it's supposed to be an opaque piece
  of parser state.

Changelog
=========

* Droped support for Python <= 3.7
  (by @elprans in 4d8c72a8)

* Reformat with Black
  (by @elprans in 468ecd0a)

* Add thorough type annotations
  (by @elprans in 995c7468)

* Massively speedup parser table generation
  (by @elprans in acb3a702)

* Stop passing parser instance to Symbol instances
  (by @elprans in c4ce270d)

* Add the ability to specify a callback directly after Spec unpickling
  (by @elprans in bd2e59e1)

* Add the ability to build parsing with mypyc
  (by @elprans in 657f3cc9)