### PR TITLE
Fix unpickling when compiled with newer mypycs

### DIFF
--- a/parsing/ast.py
+++ b/parsing/ast.py
@@ -7,7 +7,10 @@ constructed in the process.
 
 from __future__ import annotations
 
+from mypy_extensions import mypyc_attr
 
+
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class Symbol:
     pass
 

--- a/parsing/automaton.py
+++ b/parsing/automaton.py
@@ -15,6 +15,7 @@ from typing import (
     Tuple,
     Type,
 )
+from mypy_extensions import mypyc_attr
 
 import collections
 import inspect
@@ -97,6 +98,7 @@ def computeFirstSet(s: Tuple[SymbolSpec, ...]) -> frozenset[SymbolSpec]:
     return firstSet
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class ItemSet:
     def __init__(self, items: Iterable[Tuple[Item, set[SymbolSpec]]]) -> None:
         self._kernel: Dict[Item, set[SymbolSpec]] = {}
@@ -216,9 +218,9 @@ class ItemSet:
     def goto(self, sym: SymbolSpec) -> ItemSet | None:
         items = self._symMap.get(sym)
         if items:
-            return ItemSet(
+            return ItemSet([
                 (i.production.item(i.dotPos + 1), self._all[i]) for i in items
-            )
+            ])
         else:
             return None
 
@@ -274,6 +276,7 @@ class ItemSet:
         return True
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class Spec(interfaces.Spec):
     """
     The Spec class contains the read-only data structures that the Parser

--- a/parsing/grammar.py
+++ b/parsing/grammar.py
@@ -38,6 +38,8 @@ from typing import (
     Type,
 )
 
+from mypy_extensions import mypyc_attr
+
 import re
 import sys
 from parsing.ast import Token, Nonterm
@@ -48,6 +50,7 @@ if TYPE_CHECKING:
     import types
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class PrecedenceSpec:
     assoc_tok_re: ClassVar[re.Pattern[str]] = re.compile(
         r"([<>=])([A-Za-z]\w*)"
@@ -83,11 +86,13 @@ class PrecedenceSpec:
         )
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class PrecedenceRef(PrecedenceSpec):
     def __init__(self, name: str) -> None:
         super().__init__(name, "fail", {})
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class SymbolSpec:
     name: str
     prec: PrecedenceSpec
@@ -122,6 +127,7 @@ class SymbolSpec:
         return ret
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class NontermSpec(SymbolSpec):
     token_re: ClassVar[re.Pattern[str]] = re.compile(r"([A-Za-z]\w*)")
     precedence_tok_re: ClassVar[re.Pattern[str]] = re.compile(
@@ -193,6 +199,7 @@ class NontermSpec(SymbolSpec):
 
 
 # AKA terminal symbol.
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class TokenSpec(SymbolSpec):
     def __init__(
         self,
@@ -204,6 +211,7 @@ class TokenSpec(SymbolSpec):
         self.tokenType = tokenType
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class Item:
     production: Production
     dotPos: int
@@ -260,6 +268,7 @@ class Item:
 _item_cache: dict[tuple[Production, int], Item] = {}
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class Production:
     def __init__(
         self,
@@ -347,6 +356,7 @@ class NontermStart(Nonterm):
         pass
 
 
+@mypyc_attr(serializable=True, allow_interpreted_subclasses=True)
 class Action:
     """
     Abstract base class, subclassed by {Shift,Reduce}Action."""

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(str(_ROOT / "parsing" / "_version.py")) as f:
 
 
 USE_MYPYC = False
-MYPY_DEPENDENCY = "mypy>=0.910"
+MYPY_DEPENDENCY = "mypy>=1.4.1"
 setup_requires = []
 ext_modules = []
 


### PR DESCRIPTION
mypyc breaks pickling by default now
(https://mypyc.readthedocs.io/en/latest/differences_from_python.html#pickling-and-copying-objects),
and we need to opt out.

Somewhat surprisingly, that seems to be insufficient. When
allow_interpreted_subclasses isn't set, many of the objects will be
allegedly unpickled but none of their attributes are set. This /seems/
like a mypyc bug, but I haven't looked into it yet.