### PR TITLE
Update setup.py for setuptools 69

### DIFF
--- a/parsing/automaton.py
+++ b/parsing/automaton.py
@@ -158,7 +158,7 @@ class ItemSet:
         return self._hash
 
     def __eq__(self, other: Any) -> bool:
-        if type(other) == ItemSet:
+        if type(other) is ItemSet:
             return self._kernel.keys() == other._kernel.keys()
         else:
             return NotImplemented
@@ -589,7 +589,7 @@ class Spec(interfaces.Spec):
                                 conflict = "XXX"
                                 break
 
-                    if type(action) == ShiftAction:
+                    if type(action) is ShiftAction:
                         lines.append(
                             "%s %15r : %-6s %d [%s]"
                             % (
@@ -601,7 +601,7 @@ class Spec(interfaces.Spec):
                             )
                         )
                     else:
-                        assert type(action) == ReduceAction
+                        assert type(action) is ReduceAction
                         lines.append(
                             "%s %15r : %-6s %r"
                             % (conflict, sym, "reduce", action.production)
@@ -1715,16 +1715,16 @@ class Spec(interfaces.Spec):
     ) -> ConflictResolution:
         ret: ConflictResolution
 
-        if type(oldAct) == ShiftAction:
+        if type(oldAct) is ShiftAction:
             oldPrec = sym.prec
-        elif type(oldAct) == ReduceAction:
+        elif type(oldAct) is ReduceAction:
             oldPrec = oldAct.production.prec
         else:
             assert False
 
-        if type(newAct) == ShiftAction:
+        if type(newAct) is ShiftAction:
             newPrec = sym.prec
-        elif type(newAct) == ReduceAction:
+        elif type(newAct) is ReduceAction:
             newPrec = newAct.production.prec
         else:
             assert False
@@ -1740,9 +1740,9 @@ class Spec(interfaces.Spec):
 
             if oldPrec.assoc == "split" or newPrec.assoc == "split":
                 ret = "both"
-            elif type(newAct) == type(oldAct):
-                assert type(newAct) == ReduceAction
-                assert type(oldAct) == ReduceAction
+            elif type(newAct) is type(oldAct):
+                assert type(newAct) is ReduceAction
+                assert type(oldAct) is ReduceAction
                 # Fatal reduce/reduce conflict.
                 ret = "err"
             else:
@@ -1765,16 +1765,16 @@ class Spec(interfaces.Spec):
                     if assoc == "fail":
                         ret = "err"
                     elif assoc == "left":
-                        if type(oldAct) == ShiftAction:
+                        if type(oldAct) is ShiftAction:
                             ret = "new"
                         else:
-                            assert type(newAct) == ShiftAction
+                            assert type(newAct) is ShiftAction
                             ret = "old"
                     elif assoc == "right":
-                        if type(oldAct) == ShiftAction:
+                        if type(oldAct) is ShiftAction:
                             ret = "old"
                         else:
-                            assert type(newAct) == ShiftAction
+                            assert type(newAct) is ShiftAction
                             ret = "new"
                     elif assoc == "nonassoc":
                         ret = "neither"

--- a/parsing/glrparser.py
+++ b/parsing/glrparser.py
@@ -127,7 +127,7 @@ class Glr(Lr):
         tokenSpec = self._spec.sym_spec(token)
         self._act(token, tokenSpec)  # type: ignore
         if len(self._gss) == 0:
-            raise UnexpectedToken("Unexpected token: %r" % token)
+            raise UnexpectedToken(f"Unexpected token: {token:r}")
 
     def eoi(self) -> None:
         """
@@ -141,7 +141,7 @@ class Glr(Lr):
             for path in top.paths():
                 assert len(path) == 5
                 if self.verbose:
-                    print("   --> accept %r" % path)
+                    print(f"   --> accept {path:r}")
                 edge = path[1]
                 assert isinstance(edge, Gsse)
                 assert isinstance(edge.value, Nonterm)

--- a/parsing/glrparser.py
+++ b/parsing/glrparser.py
@@ -181,7 +181,7 @@ class Glr(Lr):
                 self._gss.pop(i)
             else:
                 for action in self._action[top.nextState][symSpec]:
-                    if type(action) == ReduceAction:
+                    if type(action) is ReduceAction:
                         if len(action.production.rhs) == 0:
                             if action.production not in epsilons:
                                 assert (
@@ -324,7 +324,7 @@ class Glr(Lr):
         for top in self._gss:
             if symSpec in self._action[top.nextState]:
                 for action in self._action[top.nextState][symSpec]:
-                    if type(action) == ReduceAction:
+                    if type(action) is ReduceAction:
                         if len(action.production.rhs) == 0:
                             if (
                                 gotos[top.nextState][action.production.lhs]
@@ -377,7 +377,7 @@ class Glr(Lr):
         for topA in prevGss:
             if symSpec in self._action[topA.nextState]:
                 for action in self._action[topA.nextState][symSpec]:
-                    if type(action) == ShiftAction:
+                    if type(action) is ShiftAction:
                         merged = False
                         for topB in self._gss:
                             if topB.nextState == topA.nextState:

--- a/parsing/lrparser.py
+++ b/parsing/lrparser.py
@@ -26,7 +26,7 @@ class Lr(Parser):
 
     def __init__(self, spec: Spec) -> None:
         if __debug__:
-            if type(self) == Lr:
+            if type(self) is Lr:
                 assert spec.pureLR
         assert spec.conflicts == 0
         self._spec = spec
@@ -86,11 +86,11 @@ class Lr(Parser):
 
             if self.verbose:
                 print("   --> %r" % action)
-            if type(action) == ShiftAction:
+            if type(action) is ShiftAction:
                 self._stack.append((sym, action.nextState))
                 break
             else:
-                assert type(action) == ReduceAction
+                assert type(action) is ReduceAction
                 self._reduce(action.production)
 
             if self.verbose:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "parsing"
 description = "LR(1) parser generator for Python and CFSM and GLR parser drivers"
 requires-python = ">=3.7.0"
-dynamic = ["version"]
-license = { file = "" }
+dynamic = ["version", "dependencies", "optional-dependencies"]
+license = { file = "LICENSE" }
 authors = [{ name = "Jason Evans", email = "jasone@canonware.com" }]
 readme = { file = "README.rst", content-type = "text/x-rst" }
 classifiers = [
@@ -15,10 +15,6 @@ classifiers = [
     'Topic :: Software Development :: Compilers',
     'Topic :: Text Processing :: General',
 ]
-dependencies = ['mypy-extensions>=1.0.0']
-
-[project.optional-dependencies]
-test = ['flake8', 'mypy>=1.4.1']
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,24 @@
 [project]
 name = "parsing"
-description = "LR(1) parser generator for Python"
+description = "LR(1) parser generator for Python and CFSM and GLR parser drivers"
 requires-python = ">=3.7.0"
 dynamic = ["version"]
+license = { file = "" }
+authors = [{ name = "Jason Evans", email = "jasone@canonware.com" }]
+readme = { file = "README.rst", content-type = "text/x-rst" }
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3',
+    'Topic :: Software Development :: Compilers',
+    'Topic :: Text Processing :: General',
+]
+dependencies = ['mypy-extensions>=1.0.0']
+
+[project.optional-dependencies]
+test = ['flake8', 'mypy>=1.4.1']
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,6 @@ from setuptools.command import build_ext as setuptools_build_ext
 _ROOT = pathlib.Path(__file__).parent
 
 
-with open(str(_ROOT / "README.rst")) as f:
-    readme = f.read()
-
-
 with open(str(_ROOT / "parsing" / "_version.py")) as f:
     for line in f:
         if line.startswith("__version__ ="):
@@ -88,26 +84,8 @@ class build_ext(setuptools_build_ext.build_ext):  # type: ignore
 
 
 setup(
-    name="parsing",
     version=VERSION,
     python_requires=">=3.7.0",
-    url="http://www.canonware.com/Parsing/",
-    license="MIT",
-    author="Jason Evans",
-    author_email="jasone@canonware.com",
-    description="A pure-Python module that implements an LR(1) "
-    "parser generator, as well as CFSM and GLR parser drivers.",
-    long_description=readme,
-    long_description_content_type="text/x-rst",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Topic :: Software Development :: Compilers",
-        "Topic :: Text Processing :: General",
-    ],
     packages=["parsing", "parsing.tests", "parsing.tests.specs"],
     package_data={"parsing": ["py.typed"]},
     setup_requires=setup_requires,
@@ -118,6 +96,5 @@ setup(
             MYPY_DEPENDENCY,
         ]
     },
-    install_requires=["mypy-extensions>=1.0.0"],
     cmdclass={"build_ext": build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -96,5 +96,6 @@ setup(
             MYPY_DEPENDENCY,
         ]
     },
+    install_requires=["mypy-extensions>=1.0.0"],
     cmdclass={"build_ext": build_ext},
 )


### PR DESCRIPTION
Move fields from setup.py into pyproject.toml. 

This is required because setuptools version 69 is reporting the following error:

```
➜  parsing git:(main) ✗ pip install .
Processing /home/aljaz/EdgeDB/parsing
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [57 lines of output]
      /tmp/pip-build-env-l5q640ua/overlay/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:75: _MissingDynamic: `optional-dependencies` defined outside of `pyproject.toml` is ignored.
      !!
      
              ********************************************************************************
              The following seems to be defined outside of `pyproject.toml`:
      
              `optional-dependencies = {'test': ['flake8', 'mypy>=1.4.1']}`
      
              According to the spec (see the link below), however, setuptools CANNOT
              consider this value unless `optional-dependencies` is listed as `dynamic`.
      
              https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
      
              To prevent this problem, you can list `optional-dependencies` under `dynamic` or alternatively
              remove the `[project]` table from your file and rely entirely on other means of
              configuration.
              ********************************************************************************
      
      !!
```